### PR TITLE
Move common types to a new file. Move enum to uint

### DIFF
--- a/radar-api/IRadarSensor.hpp
+++ b/radar-api/IRadarSensor.hpp
@@ -17,6 +17,8 @@
 #ifndef I_RADAR_SENSOR_HPP_
 #define I_RADAR_SENSOR_HPP_
 
+#include "RadarCommon.h"
+
 #include <cstdint>
 #include <string>
 #include <time.h>
@@ -28,170 +30,9 @@
 
 namespace radar_api {
 
-// A list of possible status/return codes that API can report back.
-enum ReturnCode {
-  // A default undefined value that should be used at initialization.
-  RC_UNDEFINED = 0,
-  // Operation completed successfully.
-  RC_OK,
-  // Operation failed and no more information can be provided.
-  RC_ERROR,
-  // Input parameters are invalid or out of supported range.
-  RC_BAD_INPUT,
-  // Operation timed out.
-  RC_TIMEOUT,
-  // Operation cannot be performed at the current state.
-  RC_BAD_STATE,
-  // Operation failed due to limited resources (memory, timers, mutexes, etc).
-  RC_RES_LIMIT,
-  // Operation is not supported.
-  RC_UNSUPPORTED,
-  // An internal system error that should never happen.
-  RC_OOPS
-};
-
-// A list of possible power mode states for radar sensors.
-enum RadarState {
-  // A default undefined value that should be used at initialization.
-  RSTATE_UNDEFINED = 0,
-  // Active state when radar is emitting/collecting data started.
-  RSTATE_ACTIVE,
-  // Idle state when the radar is neither ACTIVE nor SLEEP nor OFF.
-  RSTATE_IDLE,
-  // Sleep state when configuration persists but power consumption reduced.
-  RSTATE_SLEEP,
-  // When radar is currently turned off and configuration is reset.
-  RSTATE_OFF
-};
-
-// Defineis how an internal fifo buffer should behave in case of overflow.
-enum FifoMode {
-  // A default undefined value that should be used at initialization.
-  RFIFO_UNDEFINED = 0,
-  // A new burst will be ignored.
-  RFIFO_DROP_NEW,
-  // The oldest burst(s) will be dropped to release space for a new burst.
-  RFIFO_DROP_OLD
-};
-
-//--------------------------------------
-//----- Params -------------------------
-//--------------------------------------
-
-// A list of radar sensor parameters that define main characteristics.
-// A configuration slot can hold only 1 value for each MainParam.
-enum MainParam {
-  // A default undefined value that should be used at initialization.
-  RADAR_PARAM_UNDEFINED = 0,
-  // Power mode for after the burst period.
-  RADAR_PARAM_AFTERBURST_POWER_MODE,
-  // Power mode for the period between chirps.
-  RADAR_PARAM_INTERCHIRP_POWER_MODE,
-  // Duration between the start times of two consecutive bursts.
-  RADAR_PARAM_BURST_PERIOD_US,
-  // Duration between the start times of two consecutive chirps.
-  RADAR_PARAM_CHIRP_PERIOD_US,
-  // Amount of chirps within the burst.
-  RADAR_PARAM_CHIRPS_PER_BURST,
-  // The number of ADC sample values captured for each chirp.
-  RADAR_PARAM_SAMPLES_PER_CHIRP,
-  // The lower frequency at what TX antenna starts emitting the signal.
-  RADAR_PARAM_LOWER_FREQ_MHZ,
-  // The upper frequency at what TX antenna stops emitting the signal.
-  RADAR_PARAM_UPPER_FREQ_MHZ,
-  // Bit mask for enabled TX antennas.
-  RADAR_PARAM_TX_ANTENNA_MASK,
-  // Bit mask for enabled RX antennas.
-  RADAR_PARAM_RX_ANTENNA_MASK,
-  // Power for TX antennas.
-  RADAR_PARAM_TX_POWER,
-  // ADC sampling frequency.
-  RADAR_PARAM_ADC_SAMPLING_HZ
-};
-
-// A channel specific list of parameters.
-enum ChannelParam {
-  // A default undefined value that should be used at initialization.
-  CHANNEL_PARAM_UNDEFINED = 0,
-  // Variable Gain Amplifiers (VGA) in dB.
-  CHANNEL_PARAM_VGA_DB,
-  // High Phase (HP) filter gain in dB.
-  CHANNEL_PARAM_HP_GAIN_DB,
-  // High Phase (HP) cut off frequency in kHz.
-  CHANNEL_PARAM_HP_CUTOFF_KHZ
-};
-
-enum LogLevel {
-  // A default undefined value that should be used at initialization.
-  RLOG_UNDEFINED = 0,
-  // None of log messages are requested.
-  RLOG_OFF,
-  // Provide only log messages about occurred errors.
-  RLOG_ERR,
-  // Provide log messages same as for RLOG_ERR and warnings.
-  RLOG_WRN,
-  // Provide log messages same as for RLOG_WRN and informative changes.
-  RLOG_INF,
-  // Provide log messages same as for RLOG_INF and debugging info details.
-  RLOG_DBG
-};
-
 //--------------------------------------
 //----- Data types ---------------------
 //--------------------------------------
-
-// Forward declaration for a list of vensor specific parameters.
-enum VendorParam : uint16_t;
-
-// Describes a data format of burst data.
-struct BurstFormat {
-  // Sequence number for the current burst.
-  uint32_t sequence_number;
-  // Maximum value ADC sampler produces.
-  uint32_t max_sample_value;
-  // Amount of bits per single sample.
-  uint8_t bits_per_sample;
-  // Amount of samples per single chirp.
-  uint16_t samples_per_chirp;
-  // Amount of active channels in the current burst.
-  uint8_t channels_count;
-  // Amount of chirps in the current burst.
-  uint8_t chirps_per_burst;
-  // Config slot ID used to generate the current burst.
-  uint8_t config_id;
-  bool is_channels_interlieved;
-  bool is_big_endian;
-  // CRC for the current burst data buffer.
-  uint32_t burst_data_crc;
-  // Timestamp when the burst was created since radar was turned on.
-  uint32_t timestamp_ms;
-};
-
-// A semantic version holder.
-struct Version {
-  uint8_t major;
-  uint8_t minor;
-  uint8_t patch;
-  uint8_t build;
-};
-
-// The general information about the radar sensor hardware and software.
-struct SensorInfo {
-  // Name of the radar sensor.
-  std::string name;
-  // Vendor name.
-  std::string vendor;
-  // ID that identifies this sensor.
-  uint32_t device_id;
-  // The radar driver version.
-  Version driver_version;
-  // The Radar API version that the current driver supports.
-  Version api_version;
-  // Maximum ADC sampling rate in hertz.
-  uint64_t max_sampling_rate_hz;
-  // Current sensor state
-  RadarState state;
-};
 
 /*
  * @brief A Radar data observer that allows application to be notified
@@ -254,14 +95,14 @@ class IRadarSensor {
    *
    * @param observer pointer to the implmenetation of the interface to add.
    */
-  virtual ReturnCode AddObserver(IRadarSensorObserver* observer) = 0;
+  virtual RadarReturnCode AddObserver(IRadarSensorObserver* observer) = 0;
 
   /*
    * @brief Remove the previously registered observer from subscribers list.
    *
    * @param observer pointer to the implmenetation of the interface to remove.
    */
-  virtual ReturnCode RemoveObserver(IRadarSensorObserver* observer) = 0;
+  virtual RadarReturnCode RemoveObserver(IRadarSensorObserver* observer) = 0;
 
 
   // Power management.
@@ -271,27 +112,27 @@ class IRadarSensor {
    *
    * @param state a pointer to the state that will be set.
    */
-  virtual ReturnCode GetRadarState(RadarState& state) = 0;
+  virtual RadarReturnCode GetRadarState(RadarState& state) = 0;
 
   /*
    * @brief Turn on the radar.
    */
-  virtual ReturnCode TurnOn(void) = 0;
+  virtual RadarReturnCode TurnOn(void) = 0;
 
   /*
    * @brief Turn off the radar.
    */
-  virtual ReturnCode TurnOff(void) = 0;
+  virtual RadarReturnCode TurnOff(void) = 0;
 
   /*
    * @brief Put the radar to sleep and preserve configuration.
    */
-  virtual ReturnCode GoSleep(void) = 0;
+  virtual RadarReturnCode GoSleep(void) = 0;
 
   /*
    * @brief Wake up the radar.
    */
-  virtual ReturnCode WakeUp(void) = 0;
+  virtual RadarReturnCode WakeUp(void) = 0;
 
   // Configuration.
 
@@ -300,14 +141,14 @@ class IRadarSensor {
    *
    * @param mode a new fifo mode for the internal buffer.
    */
-  virtual ReturnCode SetFifoMode(FifoMode mode) = 0;
+  virtual RadarReturnCode SetFifoMode(RadarFifoMode mode) = 0;
 
   /*
    * Get the total available configuration slots.
    *
    * @param num_slots where the number of config slots to write.
    */
-  virtual ReturnCode GetNumConfigSlots(int8_t& num_slots) = 0;
+  virtual RadarReturnCode GetNumConfigSlots(int8_t& num_slots) = 0;
 
   /*
    * @brief Activate a specified configuration slot. Does not start the radar.
@@ -317,14 +158,14 @@ class IRadarSensor {
    * @note This function will perform the final configuration check for
    *       compatibility before activating.
    */
-  virtual ReturnCode ActivateConfig(uint8_t slot_id) = 0;
+  virtual RadarReturnCode ActivateConfig(uint8_t slot_id) = 0;
 
   /*
    * @brief Deactivate a specified configuration slot.
    *
    * @param slot_id a configuration slot ID to deactivate.
    */
-  virtual ReturnCode DeactivateConfig(uint8_t slot_id) = 0;
+  virtual RadarReturnCode DeactivateConfig(uint8_t slot_id) = 0;
 
   /*
    * @brief Check if the configuration slot is active.
@@ -332,7 +173,7 @@ class IRadarSensor {
    * @param slot_ids a vector to be filled with IDs of
    *        active config slots.
    */
-  virtual ReturnCode GetActiveConfigs(std::vector<uint8_t>& slot_ids) = 0;
+  virtual RadarReturnCode GetActiveConfigs(std::vector<uint8_t>& slot_ids) = 0;
 
   /*
    * @brief Get a main radar parameter.
@@ -341,8 +182,8 @@ class IRadarSensor {
    * @param id a parameter ID to be read.
    * @param value where a parameter value will be written into.
    */
-  virtual ReturnCode GetMainParam(uint32_t slot_id, MainParam id,
-                                  uint32_t& value) = 0;
+  virtual RadarReturnCode GetMainParam(uint32_t slot_id, RadarMainParam id,
+      uint32_t& value) = 0;
 
   /*
    * @brief Get a main radar parameter.
@@ -351,8 +192,8 @@ class IRadarSensor {
    * @param id a parameter ID to be set.
    * @param value a new value for the parameter.
    */
-  virtual ReturnCode SetMainParam(uint32_t slot_id, MainParam id,
-                                  uint32_t value) = 0;
+  virtual RadarReturnCode SetMainParam(uint32_t slot_id, RadarMainParam id,
+      uint32_t value) = 0;
 
   /*
    * @brief Get a main radar parameter range of acceptable values.
@@ -361,8 +202,8 @@ class IRadarSensor {
    * @param min_value where a minimum parameter value will be set.
    * @param max_value where a maximum parameter value will be set.
    */
-  virtual ReturnCode GetMainParamRange(MainParam id, uint32_t& min_value,
-                                       uint32_t& max_value) = 0;
+  virtual RadarReturnCode GetMainParamRange(RadarMainParam id,
+      uint32_t& min_value, uint32_t& max_value) = 0;
 
   /*
    * @brief Get a channel specific parameter.
@@ -372,8 +213,8 @@ class IRadarSensor {
    * @param id a parameter ID to read.
    * @param value to where a parameter value will be written into.
    */
-  virtual ReturnCode GetChannelParam(uint32_t slot_id, uint8_t channel_id,
-                                     ChannelParam id, uint32_t& value) = 0;
+  virtual RadarReturnCode GetChannelParam(uint32_t slot_id, uint8_t channel_id,
+      RadarChannelParam id, uint32_t& value) = 0;
 
   /*
    * @brief Set a channel specific parameter.
@@ -383,8 +224,8 @@ class IRadarSensor {
    * @param id a parameter ID to set.
    * @param value a new value for the parameter.
    */
-  virtual ReturnCode SetChannelParam(uint32_t slot_id, uint8_t channel_id,
-                                     ChannelParam id, uint32_t value) = 0;
+  virtual RadarReturnCode SetChannelParam(uint32_t slot_id, uint8_t channel_id,
+      RadarChannelParam id, uint32_t value) = 0;
 
   /*
    * @brief Get a channel pamaeter range of acceptable values.
@@ -393,8 +234,8 @@ class IRadarSensor {
    * @param min_value where a minimum parameter value will be set.
    * @param max_value where a maximum parameter value will be set.
    */
-  virtual ReturnCode GetChannelParamRange(ChannelParam id, uint32_t& min_value,
-                                          uint32_t& max_value) = 0;
+  virtual RadarReturnCode GetChannelParamRange(RadarChannelParam id,
+      uint32_t& min_value, uint32_t& max_value) = 0;
 
   /*
    * @brief Get a vendor specific parameter.
@@ -403,7 +244,8 @@ class IRadarSensor {
    * @param id a vendor specific parameter ID to read.
    * @param value to where a parameter value will be written into.
    */
-  virtual ReturnCode GetVendorParam(uint32_t slot_id, VendorParam id, uint32_t& value) = 0;
+  virtual RadarReturnCode GetVendorParam(uint32_t slot_id, RadarVendorParam id,
+      uint32_t& value) = 0;
 
   /*
    * @brief Set a vendor specific parameter.
@@ -412,26 +254,27 @@ class IRadarSensor {
    * @param id a parameter ID to set.
    * @param value a new value for the parameter.
    */
-  virtual ReturnCode SetVendorParam(uint32_t slot_id, VendorParam id, uint32_t value) = 0;
+  virtual RadarReturnCode SetVendorParam(uint32_t slot_id, RadarVendorParam id,
+      uint32_t value) = 0;
 
   // Running.
 
   /*
    * @brief Start running the radar with active configuration.
    */
-  virtual ReturnCode StartDataStreaming(void) = 0;
+  virtual RadarReturnCode StartDataStreaming(void) = 0;
 
   /*
    * @brief Stop running the radar.
    */
-  virtual ReturnCode StopDataStreaming(void) = 0;
+  virtual RadarReturnCode StopDataStreaming(void) = 0;
 
   /*
    * @brief Check if the radar has a new burst ready to read.
    *
    * @param is_ready where the result will be set.
    */
-  virtual ReturnCode IsBurstReady(bool& is_ready) = 0;
+  virtual RadarReturnCode IsBurstReady(bool& is_ready) = 0;
 
   /*
    * @brief Initiate reading a new burst.
@@ -440,9 +283,8 @@ class IRadarSensor {
    * @param raw_radar_data where a burst data to be written.
    * @param timeout the maximum time to wait if the burst frame is not ready.
    */
-  virtual ReturnCode ReadBurst(BurstFormat& format,
-                               std::vector<uint8_t>& raw_radar_data,
-                               timespec timeout) = 0;
+  virtual RadarReturnCode ReadBurst(RadarBurstFormat& format,
+      std::vector<uint8_t>& raw_radar_data, timespec timeout) = 0;
 
   // Miscellaneous.
 
@@ -452,21 +294,21 @@ class IRadarSensor {
    *
    * @param country_code a ISO 3166-1 alpha-2 country code.
    */
-  virtual ReturnCode SetCountryCode(const std::string& country_code) = 0;
+  virtual RadarReturnCode SetCountryCode(const std::string& country_code) = 0;
 
   /*
    * @brief Get radar sensor info.
    *
    * @param info where the sensor info to be filled in.
    */
-  virtual ReturnCode GetSensorInfo(SensorInfo& info) = 0;
+  virtual RadarReturnCode GetSensorInfo(SensorInfo& info) = 0;
 
   /*
    * @brief Set a run time log level for radar API impl.
    *
    * @param level new log level.
    */
-  virtual ReturnCode SetLogLevel(LogLevel level) = 0;
+  virtual RadarReturnCode SetLogLevel(RadarLogLevel level) = 0;
 
   /*
    * @brief Get all register values from the radar sensor.
@@ -474,7 +316,7 @@ class IRadarSensor {
    * @param registers where the pair of register's address and value
    *        to be written.
    */
-  virtual ReturnCode GetAllRegisters(
+  virtual RadarReturnCode GetAllRegisters(
       std::vector<std::pair<uint32_t, uint32_t>>& registers) = 0;
 
   /*
@@ -483,14 +325,14 @@ class IRadarSensor {
    * @param address an address to read.
    * @param value where the register's value will be written into.
    */
-  virtual ReturnCode GetRegister(uint32_t address, uint32_t& value) = 0;
+  virtual RadarReturnCode GetRegister(uint32_t address, uint32_t& value) = 0;
   /*
    * @brief Set a register value directly to the sensor.
    *
    * @param address an address of the register to set.
    * @param value a new value to set.
    */
-  virtual ReturnCode SetRegister(uint32_t address, uint32_t value) = 0;
+  virtual RadarReturnCode SetRegister(uint32_t address, uint32_t value) = 0;
 };
 
 // Return the intsance of the RadarSensor implementation.

--- a/radar-api/RadarCommon.h
+++ b/radar-api/RadarCommon.h
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2022 CTA Radar API Technical Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RADAR_API_RADAR_COMMON_H_
+#define RADAR_API_RADAR_COMMON_H_
+
+#include <inttypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//--------------------------------------
+//----- Constants ----------------------
+//--------------------------------------
+
+// A list of possible status/return codes that API can report back.
+typedef uint16_t RadarReturnCode;
+
+// A default undefined value that should be used at initialization.
+#define RC_UNDEFINED        0
+// Operation completed successfully.
+#define RC_OK               1
+// Operation failed and no more information can be provided.
+#define RC_ERROR            2
+// Input parameters are invalid or out of supported range.
+#define RC_BAD_INPUT        3
+// Operation timed out.
+#define RC_TIMEOUT          4
+// Operation cannot be performed at the current state.
+#define RC_BAD_STATE        5
+// Operation failed due to limited resources (memory, timers, mutexes, etc).
+#define RC_RES_LIMIT        6
+// Operation is not supported.
+#define RC_UNSUPPORTED      7
+// An internal system error that should never happen.
+#define RC_OOPS             8
+
+// A list of possible power mode states for radar sensors.
+typedef uint16_t RadarState;
+
+// A default undefined value that should be used at initialization.
+#define RSTATE_UNDEFINED    0
+// Active state when radar is emitting/collecting data started.
+#define RSTATE_ACTIVE       1
+// Idle state when the radar is neither ACTIVE nor SLEEP nor OFF.
+#define RSTATE_IDLE         2
+// Sleep state when configuration persists but power consumption reduced.
+#define RSTATE_SLEEP        3
+// When radar is currently turned off and configuration is reset.
+#define RSTATE_OFF          4
+
+// Defineis how an internal fifo buffer should behave in case of overflow.
+typedef uint16_t RadarFifoMode;
+
+// A default undefined value that should be used at initialization.
+#define RFIFO_UNDEFINED     0
+// A new burst will be ignored.
+#define RFIFO_DROP_NEW      1
+// The oldest burst(s) will be dropped to release space for a new burst.
+#define RFIFO_DROP_OLD      2
+
+// Log level
+typedef uint32_t RadarLogLevel;
+
+// A default undefined value that should be used at initialization.
+#define RLOG_UNDEFINED      0
+// None of log messages are requested.
+#define RLOG_OFF            1
+// Provide only log messages about occurred errors.
+#define RLOG_ERR            2
+// Provide log messages same as for RLOG_ERR and warnings.
+#define RLOG_WRN            3
+// Provide log messages same as for RLOG_WRN and informative changes.
+#define RLOG_INF            4
+// Provide log messages same as for RLOG_INF and debugging info details.
+#define RLOG_DBG            5
+
+
+//--------------------------------------
+//----- Params -------------------------
+//--------------------------------------
+
+// A list of radar sensor parameters that define main characteristics.
+// A configuration slot can hold only 1 value for each MainParam.
+typedef uint32_t RadarMainParam;
+
+// A default undefined value that should be used at initialization.
+#define RADAR_PARAM_UNDEFINED               0
+// Power mode for after the burst period.
+#define RADAR_PARAM_AFTERBURST_POWER_MODE   1
+// Power mode for the period between chirps.
+#define RADAR_PARAM_INTERCHIRP_POWER_MODE   2
+// Duration between the start times of two consecutive bursts.
+#define RADAR_PARAM_BURST_PERIOD_US         3
+// Duration between the start times of two consecutive chirps.
+#define RADAR_PARAM_CHIRP_PERIOD_US         4
+// Amount of chirps within the burst.
+#define RADAR_PARAM_CHIRPS_PER_BURST        5
+// The number of ADC sample values captured for each chirp.
+#define RADAR_PARAM_SAMPLES_PER_CHIRP       6
+// The lower frequency at what TX antenna starts emitting the signal.
+#define RADAR_PARAM_LOWER_FREQ_MHZ          7
+// The upper frequency at what TX antenna stops emitting the signal.
+#define RADAR_PARAM_UPPER_FREQ_MHZ          8
+// Bit mask for enabled TX antennas.
+#define RADAR_PARAM_TX_ANTENNA_MASK         9
+// Bit mask for enabled RX antennas.
+#define RADAR_PARAM_RX_ANTENNA_MASK        10
+// Power for TX antennas.
+#define RADAR_PARAM_TX_POWER               11
+// ADC sampling frequency.
+#define RADAR_PARAM_ADC_SAMPLING_HZ        12
+
+// A channel specific list of parameters.
+typedef uint32_t RadarChannelParam;
+
+// A default undefined value that should be used at initialization.
+#define CHANNEL_PARAM_UNDEFINED             0
+// Variable Gain Amplifiers (VGA) in dB.
+#define CHANNEL_PARAM_VGA_DB                1
+// High Phase (HP) filter gain in dB.
+#define CHANNEL_PARAM_HP_GAIN_DB            2
+// High Phase (HP) cut off frequency in kHz.
+#define CHANNEL_PARAM_HP_CUTOFF_KHZ         3
+
+
+// Forward declaration for a list of vensor specific parameters.
+typedef uint32_t RadarVendorParam;
+
+//--------------------------------------
+//----- Data types ---------------------
+//--------------------------------------
+
+// Describes a data format of burst data.
+typedef struct RadarBurstFormat_s {
+  // Sequence number for the current burst.
+  uint32_t sequence_number;
+  // Maximum value ADC sampler produces.
+  uint32_t max_sample_value;
+  // Amount of bits per single sample.
+  uint8_t bits_per_sample;
+  // Amount of samples per single chirp.
+  uint16_t samples_per_chirp;
+  // Amount of active channels in the current burst.
+  uint8_t channels_count;
+  // Amount of chirps in the current burst.
+  uint8_t chirps_per_burst;
+  // Config slot ID used to generate the current burst.
+  uint8_t config_id;
+  union {
+    struct {
+      // True/1 if channels and samples are interleaved.
+      uint16_t is_channels_interlieved: 1;
+      // True/1 if a word is in big endian.
+      uint16_t is_big_endian: 1;
+      // Reserved for future use.
+      uint16_t reserved: 14;
+    };
+    uint16_t flags;
+  };
+  // CRC for the current burst data buffer.
+  uint32_t burst_data_crc;
+  // Timestamp when the burst was created since radar was turned on.
+  uint32_t timestamp_ms;
+} RadarBurstFormat;
+
+// A semantic version holder.
+typedef struct Version_s {
+  uint8_t major;
+  uint8_t minor;
+  uint8_t patch;
+  uint8_t build;
+} Version;
+
+#define MAX_SENSOR_NAME_LEN 32
+#define MAX_VENDOR_NAME_LEN 32
+
+// The general information about the radar sensor hardware and software.
+typedef struct SensorInfo_s {
+  // Name of the radar sensor.
+  const char name[MAX_SENSOR_NAME_LEN];
+  // Vendor name.
+  const char vendor[MAX_VENDOR_NAME_LEN];
+  // ID that identifies this sensor.
+  uint32_t device_id;
+  // The radar driver version.
+  Version driver_version;
+  // The Radar API version that the current driver supports.
+  Version api_version;
+  // Maximum ADC sampling rate in hertz.
+  uint64_t max_sampling_rate_hz;
+  // Current sensor state
+  RadarState state;
+} SensorInfo;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RADAR_API_RADAR_COMMON_H_


### PR DESCRIPTION
Moved constant from enum values to uint types. This would allow extensions to add new values and customize functionality as needed.
Moved common enums and data types to a separate file.